### PR TITLE
Add .vimrc and nvim folder check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,12 @@ def main():
             print('LeafVim has finished setup. Start nvim and use the command :PlugInstall to finish plugin installation.')
 
         if ver == '2':
+            # Check if nvim folder exists. If not, create it.
+            path = os.path.expanduser("~/.config/nvim")
+            if not os.path.exists(path):
+                os.system('mkdir ~/.config/nvim')
+                print("Created ~/.config/nvim directory")
+
             print(f'Copying config file...')
             os.system('cp init.vim ~/.config/nvim/init.vim')
             print('Copied to ~/.config/nvim/init.vim')

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def main():
         ver = input(''':: ''')
 
         if ver == '1':
-            # Check if nvim folder exists. If not, create it.
+            # Check if .vimrc folder exists. If not, create it.
             path = os.path.expanduser("~/.vimrc")
             if not os.path.exists(path):
                 os.system('mkdir ~/.vimrc')

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,12 @@ def main():
         ver = input(''':: ''')
 
         if ver == '1':
+            # Check if nvim folder exists. If not, create it.
+            path = os.path.expanduser("~/.vimrc")
+            if not os.path.exists(path):
+                os.system('mkdir ~/.vimrc')
+                print("Created ~/.vimrc directory")
+
             print(f'Copying config file...')
             os.system('cp init.vim ~/.vimrc')
             print('Copied to ~/.vimrc')


### PR DESCRIPTION
Checking if the folders exist. If they don't, we create them before copying files. 

This prevents the installer from terminating.